### PR TITLE
Fixes for newer Python versions

### DIFF
--- a/src/autolatex2/cli/commands/document.py
+++ b/src/autolatex2/cli/commands/document.py
@@ -32,7 +32,10 @@ class MakerAction(extended_maker_action):
 
 	id = 'document'
 
-	alias = 'gen_doc'
+	# When set, this alias is causing the following error
+	# > argparse.ArgumentError: argument COMMAND: conflicting subparser alias: gen_doc
+	# It appears to conflict with the `view` command
+	#alias = 'gen_doc'
 
 	help = _T('Performs all processing actions that are required to produce the PDF, DVI or Postscript. The actions set includes LaTeX, BibTeX, Makeindex, Dvips, etc.')
 

--- a/src/autolatex2/cli/main.py
+++ b/src/autolatex2/cli/main.py
@@ -543,7 +543,7 @@ class AbstractAutoLaTeXMain(ABC):
 		# --pdflatex
 		class PdflatexCmdAction(argparse.Action):
 			def __call__(actionself, parser, namespace, value, option_string=None):
-				self.configuration.latexCompiler = 'pdflatex'
+				self.configuration.generation.latexCompiler = 'pdflatex'
 		tex_tool_group.add_argument('--pdflatex',
 			action=PdflatexCmdAction,
 			nargs=0, 
@@ -552,7 +552,7 @@ class AbstractAutoLaTeXMain(ABC):
 		# --latex
 		class LatexCmdAction(argparse.Action):
 			def __call__(actionself, parser, namespace, value, option_string=None):
-				self.configuration.latexCompiler = 'latex'
+				self.configuration.generation.latexCompiler = 'latex'
 		tex_tool_group.add_argument('--latex',
 			action=LatexCmdAction,
 			nargs=0, 
@@ -561,7 +561,7 @@ class AbstractAutoLaTeXMain(ABC):
 		# --lualatex
 		class LualatexCmdAction(argparse.Action):
 			def __call__(actionself, parser, namespace, value, option_string=None):
-				self.configuration.latexCompiler = 'lualatex'
+				self.configuration.generation.latexCompiler = 'lualatex'
 		tex_tool_group.add_argument('--lualatex',
 			action=LualatexCmdAction,
 			nargs=0, 
@@ -570,7 +570,7 @@ class AbstractAutoLaTeXMain(ABC):
 		# --xelatex
 		class XelatexCmdAction(argparse.Action):
 			def __call__(actionself, parser, namespace, value, option_string=None):
-				self.configuration.latexCompiler = 'xelatex'
+				self.configuration.generation.latexCompiler = 'xelatex'
 		tex_tool_group.add_argument('--xelatex',
 			action=XelatexCmdAction,
 			nargs=0, 

--- a/src/autolatex2/make/maketool.py
+++ b/src/autolatex2/make/maketool.py
@@ -508,7 +508,7 @@ class AutoLaTeXMaker(Runner):
 						self.__latexCLI.append(self.__instance_compiler_definition['synctex'])
 
 				target = self.__instance_compiler_definition['to_%s' % (outtype)]
-				if target:
+				if target is not None:
 					if isinstance(target, list):
 						self.__latexCLI.extend(target)
 					else:

--- a/src/autolatex2/make/maketool.py
+++ b/src/autolatex2/make/maketool.py
@@ -791,7 +791,7 @@ class AutoLaTeXMaker(Runner):
 		'''
 		logging.debug(_T("Reading log file: %s") % (os.path.basename(logFile)))
 		if os.path.exists(logFile):
-			with open(logFile, 'r') as f:
+			with open(logFile, 'r', errors='ignore') as f:
 				content = f.read()
 			if texutils.extractTeXWarningFromLine(content, self.__standardsWarnings):
 				if loop:

--- a/src/autolatex2/tex/citationanalyzer.py
+++ b/src/autolatex2/tex/citationanalyzer.py
@@ -25,7 +25,7 @@ Tools for extracting the bibliography citations from a AUX file or a BSF file.
 import os
 import re
 import base64
-from Crypto.Hash import MD5
+from hashlib import md5
 
 from autolatex2.tex import texparser
 
@@ -128,8 +128,8 @@ class AuxiliaryCitationAnalyzer(texparser.Observer):
 		if self.__md5 is None:
 			if self.__citations is None:
 				self.run()
-			h = MD5.new()
-			h.update(bytes('\\'.join(self.citations), 'UTF-8'))
+
+			h = md5(bytes('\\'.join(self.citations), 'UTF-8'))
 			value = h.digest()
 			self.__md5 = base64.encodebytes(value).decode('UTF-8').strip()
 		return self.__md5
@@ -261,8 +261,7 @@ class BiblatexCitationAnalyzer(texparser.Observer):
 		if self.__md5 is None:
 			if self.__citations is None:
 				self.run()
-			h = MD5.new()
-			h.update(bytes('\\'.join(self.citations), 'UTF-8'))
+			h = md5(bytes('\\'.join(self.citations), 'UTF-8'))
 			value = h.digest()
 			self.__md5 = base64.encodebytes(value).decode('UTF-8').strip()
 		return self.__md5

--- a/src/autolatex2/tex/glossaryanalyzer.py
+++ b/src/autolatex2/tex/glossaryanalyzer.py
@@ -24,7 +24,7 @@ Tools for that is extracting the definitions of glossaries from a GLS file.
 
 import os
 import base64
-from Crypto.Hash import MD5
+from hashlib import md5
 
 from autolatex2.tex import texparser
 
@@ -103,8 +103,7 @@ class GlossaryAnalyzer(texparser.Observer):
 		if self.__md5 is None:
 			if self.__glossaryEntries is None:
 				self.run()
-			h = MD5.new()
-			h.update(bytes('\\'.join(self.glossaryEntries), 'UTF-8'))
+			h = md5(bytes('\\'.join(self.glossaryEntries), 'UTF-8'))
 			value = h.digest()
 			self.__md5 = base64.encodebytes(value).decode('UTF-8').strip()
 		return self.__md5

--- a/src/autolatex2/tex/indexanalyzer.py
+++ b/src/autolatex2/tex/indexanalyzer.py
@@ -24,7 +24,7 @@ Tools for that is extracting the definitions of indexes from an IDX file.
 
 import os
 import base64
-from Crypto.Hash import MD5
+from hashlib import md5
 
 from autolatex2.tex import texparser
 
@@ -103,8 +103,7 @@ class IndexAnalyzer(texparser.Observer):
 		if self.__md5 is None:
 			if self.__indexes is None:
 				self.run()
-			h = MD5.new()
-			h.update(bytes('\\'.join(self.indexes), 'UTF-8'))
+			h = md5(bytes('\\'.join(self.indexes), 'UTF-8'))
 			value = h.digest()
 			cd = base64.encodebytes(value).decode('UTF-8').strip()
 			self.__md5 = cd


### PR DESCRIPTION
- [Use hashlib instead of Crypto.Hash](https://github.com/gallandarakhneorg/autolatex/commit/e0dcedafc7bf59596c5d503015b559811644b59b)

    The rationale is that `hashlib` is part of the standard library while `Crypto` is not. Depending on `Crypto` just for hashing is not compelling anymore. Less dependencies is 1) good for reducing developer friction and 2) easier to manage.

- [Disable "gen_doc" alias for document command](https://github.com/gallandarakhneorg/autolatex/commit/a69672c2e6adca7477e0824d11ae7c4e09d12d37)

    When set, this alias is causing the following error:

    > argparse.ArgumentError: argument COMMAND: conflicting subparser alias: gen_doc

    It appears to conflict with the `view` command

    Likely due to some change in the argparse module of recent Python distributions.

- [Fix tex_tool_group CLI arguments](https://github.com/gallandarakhneorg/autolatex/pull/115/commits/1052eaa563ff70f06aa3b12f2dcf96852032eea9)

    For instance --xelatex was ignored because the property wasn’t set on the right object.

- [Fix --xelatex option](https://github.com/gallandarakhneorg/autolatex/pull/115/commits/d8fd4d21aef9adef5d5e96f708787da7484c34b9)

    xelatex is outputing PDFs by default, and thus it’s definition contains an empty list for `to_pdf`. However, `[]` is considered to be "falsy", and thus the condition is (erroneously) unmet when xelatex is used.

- [Parse Tex log files in a more lenient way](https://github.com/gallandarakhneorg/autolatex/pull/115/commits/aabdb1467a28de4e8e361c466ef7bf0c1662e9eb)

    The Tex log files may contain non-UTF-8 sequences.

You may want to do something else about the command alias problem, but this is at least unblocking me. Feel free to merge and address later, or push a commit on my branch directly. (Disclaimer: I’m not using Python anymore these days, and I’m not very familiar with the `argparse` module.)